### PR TITLE
bug/search-list-does-not-populate-hero-detail

### DIFF
--- a/src/app/hero-search/hero-search.component.html
+++ b/src/app/hero-search/hero-search.component.html
@@ -4,7 +4,7 @@
   
   <ul class="search-result">
     <li *ngFor="let hero of heroes$ | async">
-      <a routerLink="/detail/${{hero.id}}">{{hero.name}}</a>
+      <a routerLink="/detail/{{hero.id}}">{{hero.name}}</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
# Description
When clicking a hero list tile from the search bar did not populate the hero-detail component

# Solution
There was an extra `$` added in the hero-search html template